### PR TITLE
Setup.py properly declares dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name         = 'requests_ntlm',
     version      = '0.0.2.1',
     packages     = [ 'requests_ntlm' ],
-    requires     = [ 'requests(>=1.0.0)', 'ntlm' ],
+    install_requires = [ 'requests>=1.0.0', 'python-ntlm' ],
     provides     = [ 'requests_ntlm' ],
     author       = 'Ben Toews',
     author_email = 'mastahyeti@gmail.com',


### PR DESCRIPTION
This simple fix enables pip et. al. to properly download all the dependencies.

I think there's room for other improvements in this setup.py file but I'll leave that for a second pull request.

Fixes #15.
