### PR TITLE
Better error message if user omits domain from username

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -15,9 +15,11 @@ class HttpNtlmAuth(AuthBase):
         if ntlm is None:
             raise Exception("NTLM libraries unavailable")
         #parse the username
-        user_parts = username.split('\\', 1)
-        self.domain = user_parts[0].upper()
-        self.username = user_parts[1]
+        try:
+            self.domain, self.username = username.split('\\', 1)
+        except ValueError:
+            raise ValueError("username should be in 'domain\\username' format.")
+        self.domain = self.domain.upper()
 
         self.password = password
         self.adapter = HTTPAdapter()


### PR DESCRIPTION
It's an easy mistake to omit the domain from the username. The old error message was unhelpful:

> IndexError: list index out of range

Better to see

> ValueError: username should be in 'domain\username' format.
