### PR TITLE
Changed relative import for python 3 compatibility.

### DIFF
--- a/requests_ntlm/__init__.py
+++ b/requests_ntlm/__init__.py
@@ -1,3 +1,3 @@
-from requests_ntlm import HttpNtlmAuth
+from .requests_ntlm import HttpNtlmAuth
 
 __all__ = [HttpNtlmAuth]


### PR DESCRIPTION
I found that I could not use this package with python 3 due the following import error.

ImportError: cannot import name HttpNtlmAuth

This change allows it to be imported. I have not confirmed complete success with python 3 yet, this was the first step.

I don't know if this breaks python 2 compatibility.
