### PR TITLE
Support MS Exchange 2013 NTLM challenge

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -55,7 +55,7 @@ class HttpNtlmAuth(AuthBase):
 
         # get the challenge
         auth_header_value = response2.headers[auth_header_field]
-        ntlm_header_value = filter(lambda s: s.startswith('NTLM '), auth_header_value.split(','))[0]
+        ntlm_header_value = filter(lambda s: s.startswith('NTLM '), auth_header_value.split(','))[0].strip()
         ServerChallenge, NegotiateFlags = ntlm.parse_NTLM_CHALLENGE_MESSAGE(ntlm_header_value[5:])
 
         # build response


### PR DESCRIPTION
I have an MS Exchange 2013 server that likes to send this auth header as a challenge:

'www-authenticate': 'NTLM YadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYadaYada, Negotiate'

I'm not sure why MS chose to break the protocol, but anyway python-ntlm chokes on the superfluous "Negotiate" at the end, and removing it lets me communicate with the server.
