### PR TITLE
Fix for compatibility with requests-2.3.0

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -48,8 +48,10 @@ class HttpNtlmAuth(AuthBase):
         # and not the real content, so the content will be short anyway.
         args_nostream = dict(args, stream=False)
         response2 = self.adapter.send(request, **args_nostream)
+
         # needed to make NTLM auth compatible with requests-2.3.0
         response2.content
+
         # this is important for some web applications that store authentication-related info in cookies (it took a long time to figure out)
         if response2.headers.get('set-cookie'):
             request.headers['Cookie'] = response2.headers.get('set-cookie')


### PR DESCRIPTION
Here's what I did to test-
1. change [these lines](https://github.com/requests/requests-ntlm/blob/master/tests/test_requests_ntlm.py#L9-L11) to contain my own NTLM server details
2. Verify without the patch, it fails under requests 2.3.0 (redacted the actual URL in case my employer minds) 
   ![image](https://cloud.githubusercontent.com/assets/7807926/3199467/f7cca514-ed68-11e3-8940-e1e9c07b8a48.png)
3. Test under requests 2.2.1 and 2.3.0, to verify that tests pass with both versions
   ![image](https://cloud.githubusercontent.com/assets/7807926/3199491/561b8ab8-ed69-11e3-93bd-58d501276e87.png)

![image](https://cloud.githubusercontent.com/assets/7807926/3199492/58dfaa72-ed69-11e3-94e4-485303b269d5.png)
