### PR TITLE
Allow empty domain

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -65,9 +65,8 @@ class HttpNtlmAuth(AuthBase):
                 adapter = session.get_adapter(response.request.url)
 
         # initial auth header with username. will result in challenge
-        auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(
-            "%s\\%s" % (self.domain, self.username)
-        )
+        msg = "%s\\%s" % (self.domain, self.username) if self.domain else self.username
+        auth = 'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(msg)
         request.headers[auth_header] = auth
 
         # A streaming response breaks authentication.


### PR DESCRIPTION
I've encountered an NTLM-authenticated Exchange server in the wild that allows usernames without the domain name. This works at least in Chrome and curl using NTLM auth. This patch works for me and is the least intrusive I could think of. It also keeps the foot-shooting countermeasures intact, and I'm fine with providing the username to requests-ntlm as "\foo_user" and not just "foo_user".
