### PR TITLE
Explicitly close initial connection

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -48,6 +48,7 @@ class HttpNtlmAuth(AuthBase):
         if auth_header in response.request.headers:
             return response
 
+        response.connection.close()
         request = copy_request(response.request)
 
         content_length = int(request.headers.get('Content-Length', '0'),


### PR DESCRIPTION
The initial socket needs to be explicitly closed to avoid "ResourceWarning: unclosed <ssl.SSLSocket fd= ...>" warnings from urllib3.

In the self.session case, this is also needed to avoid connection pool starvation. This is observed when sessions are forced to only have one connection:

   s = Session()
   s.mount('https://', adapters.HTTPAdapter(pool_block=True, pool_connections=1, pool_maxsize=1))
