### PR TITLE
Recycle the original connection pool

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -18,8 +18,7 @@ class HttpNtlmAuth(AuthBase):
         :param str username: Username in 'domain\\username' format
         :param str password: Password or hash in
             "ABCDABCDABCDABCD:ABCDABCDABCDABCD" format.
-        :param str session: Optional requests.Session, through which
-            connections are pooled.
+        :param str session: Unused. Kept for backwards-compatibility.
         """
         if ntlm is None:
             raise Exception("NTLM libraries unavailable")
@@ -35,12 +34,6 @@ class HttpNtlmAuth(AuthBase):
         self.domain = self.domain.upper()
 
         self.password = password
-
-        self.adapter = HTTPAdapter()
-
-        # Keep a weak reference to the Session, if one is in use.
-        # This is to avoid a circular reference.
-        self.session = weakref.ref(session) if session else None
 
     def retry_using_http_NTLM_auth(self, auth_header_field, auth_header,
                                    response, args):


### PR DESCRIPTION
In the non-session case, the original code was leaking sockets because 'response2' would use another connection pool than 'response'. The original socket from 'response' would lose all references and be garbage-collected.

In the session case, the original code would open an additional connection because the original connection was never returned to the pool. This causes an indefinite hang if the connection count overflows any hard limits in the session adapter.

This patch also makes self.session and self.adapter unnecessary.