### PR TITLE
python 3.2 support

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -90,7 +90,7 @@ class HttpNtlmAuth(AuthBase):
             lambda s: s.startswith('NTLM '), auth_header_value.split(',')
         ))[0].strip()
         ServerChallenge, NegotiateFlags = ntlm.parse_NTLM_CHALLENGE_MESSAGE(
-            ntlm_header_value[5:]
+            bytes(ntlm_header_value[5:], 'ascii')
         )
 
         # build response


### PR DESCRIPTION
sending a byte string to the ntlm3 engine which uses b64decode, in python 3.2 only accepts bytes but in >3.2 accepts bytes, and str