### PR TITLE
Return server's 401/407 if it doesn't claim to support NTLM/Negotiate. Fix proxy auth.

### DIFF
--- a/tests/test_requests_ntlm.py
+++ b/tests/test_requests_ntlm.py
@@ -1,7 +1,7 @@
 import unittest
 import requests
 import requests_ntlm
-import test_server
+
 
 class TestRequestsNtlm(unittest.TestCase):
 
@@ -37,6 +37,18 @@ class TestRequestsNtlm(unittest.TestCase):
 
             self.assertTrue(res.history[0].request is not res.history[1].request)
             self.assertTrue(res.history[0].request is not res.request)
+
+    def test_unrecognized_authenticate_header(self):
+        res = requests.get(url=self.test_server_url + 'basic',
+                           auth=requests_ntlm.HttpNtlmAuth(self.test_server_username,
+                                                           self.test_server_password))
+        self.assertEquals(res.status_code, 401)
+
+    def test_proxy_authenticate(self):
+        res = requests.get(url=self.test_server_url + 'proxy_negotiate',
+                           auth=requests_ntlm.HttpNtlmAuth(self.test_server_username,
+                                                           self.test_server_password))
+        self.assertEquals(res.status_code, 200)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,6 +23,30 @@ def negotiate_auth():
 def negotiate_and_ntlm_auth():
     return get_auth_response('NTLM', advertise_nego_and_ntlm=True)
 
+@app.route("/basic")
+def basic_auth():
+    return get_auth_response('Basic')
+
+@app.route("/proxy_negotiate")
+def proxy_negotiate_auth():
+    auth_type = 'Negotiate'
+    response_headers = {'Proxy-Authenticate': auth_type}
+    status_code = 407
+    response = "proxy authenticate"
+
+    # 2nd request
+    if request.headers.get('Proxy-Authorization', '') == REQUEST_2_TEMPLATE.format(auth_type):
+        response_headers = {'Proxy-Authenticate': RESPONSE_2_TEMPLATE.format(auth_type)}
+        status_code = 407
+
+    # 3rd request
+    elif request.headers.get('Proxy-Authorization', '') == REQUEST_3_TEMPLATE.format(auth_type):
+        response_headers = {}
+        status_code = 200
+        response = "authed"
+
+    return response, status_code, response_headers
+
 def get_auth_response(auth_type, advertise_nego_and_ntlm=False):
     response_headers = {'WWW-Authenticate':auth_type if not advertise_nego_and_ntlm else 'Negotiate, NTLM'}
     status_code = 401


### PR DESCRIPTION
This is a stab at fixing #69, plus an unrelated fix. For #69, the idea here is to just forge ahead and send an `Authorization: NTLM` header even if the authenticate header doesn't claim to support it, and let the server respond with a rejection. I believe this matches the old behaviour.

The other part is a fix for NTLM proxy authentication support. This fixes the list of arguments, and extends the Negotiate support to NTLM proxies.