### PR TITLE
Remove domain parsing for UPN-formatted names

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -27,13 +27,11 @@ class HttpNtlmAuth(AuthBase):
         try:
             self.domain, self.username = username.split('\\', 1)
         except ValueError:
-            try:
-                self.username, self.domain = username.split('@', 1)
-            except ValueError:
-                self.username = username
-                self.domain = '.'
+            self.username = username
+            self.domain = ''
 
-        self.domain = self.domain.upper()
+        if self.domain:
+            self.domain = self.domain.upper()
         self.password = password
 
         # This exposes the encrypt/decrypt methods used to encrypt and decrypt messages

--- a/tests/unit/test_requests_ntlm.py
+++ b/tests/unit/test_requests_ntlm.py
@@ -53,9 +53,11 @@ class TestRequestsNtlm(unittest.TestCase):
         assert actual_user == expected_user
 
     def test_username_parse_at(self):
-        test_user = 'user@domain'
-        expected_domain = 'DOMAIN'
-        expected_user = 'user'
+        test_user = 'user@domain.com'
+        # UPN format should not be split, since "stuff after @" not always == domain 
+        # (eg, email address with alt UPN suffix)
+        expected_domain = ''
+        expected_user = 'user@domain.com'
 
         context = requests_ntlm.HttpNtlmAuth(test_user, 'pass')
 
@@ -67,7 +69,7 @@ class TestRequestsNtlm(unittest.TestCase):
 
     def test_username_parse_no_domain(self):
         test_user = 'user'
-        expected_domain = '.'
+        expected_domain = ''
         expected_user = 'user'
 
         context = requests_ntlm.HttpNtlmAuth(test_user, 'pass')


### PR DESCRIPTION
Alternate fix for #85. Turns out domain should be null for UPN (according to https://msdn.microsoft.com/en-us/library/windows/desktop/aa378184(v=vs.85).aspx), and breaks default domain handling for alternate UPN suffixes (eg, email-address-as-domain-username). 

Updated tests to match current behavior.