### PR TITLE
Migrate to PySPNEGO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         python -m tests.test_server &
 
         python -m pytest \
-            --ignore=tests/functional/test_function.py \
+            --ignore=tests/functional/test_functional.py \
             --ignore=tests/test_server.py \
             --cov requests_ntlm \
             --cov-report term-missing \

--- a/README.rst
+++ b/README.rst
@@ -41,10 +41,10 @@ Requirements
 ------------
 
 - requests_
-- ntlm-auth_
+- pyspnego_
 
 .. _requests: https://github.com/kennethreitz/requests/
-.. _ntlm-auth: https://github.com/jborean93/ntlm-auth
+.. _ntlm-auth: https://github.com/jborean93/pyspnego/
 
 Authors
 -------

--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -28,16 +28,7 @@ class HttpNtlmAuth(AuthBase):
         :param str session: Unused. Kept for backwards-compatibility.
         :param bool send_cbt: Will send the channel bindings over a HTTPS channel (Default: True)
         """
-        # parse the username
-        try:
-            self.domain, self.username = username.split('\\', 1)
-        except ValueError:
-            self.username = username
-            self.domain = ''
-
-        if self.domain:
-            self.domain = self.domain.upper()
-        self.username = self.domain + "\\" + self.username
+        self.username = username
         self.password = password
         self.send_cbt = send_cbt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.0.0
-ntlm-auth>=1.0.2
+pyspnego
 cryptography>=1.3
 flask
 pytest

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="requests_ntlm",
     version="1.2.0",
     packages=["requests_ntlm"],
-    install_requires=["requests>=2.0.0", "ntlm-auth>=1.0.2", "cryptography>=1.3"],
+    install_requires=["requests>=2.0.0", "pyspnego>=0.1.6", "cryptography>=1.3"],
     python_requires=">=3.7",
     provides=["requests_ntlm"],
     author="Ben Toews",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,3 +2,6 @@
 username = 'username'
 domain = 'domain'
 password = 'password'
+
+# Genearated online as hashlib.md4 may not be available anymore
+password_md4 = '8a9d093f14f8701df17732b2bb182c74'

--- a/tests/unit/test_requests_ntlm.py
+++ b/tests/unit/test_requests_ntlm.py
@@ -3,10 +3,8 @@ import unittest
 import requests
 import requests_ntlm
 import warnings
-import hashlib
-import binascii
 
-from tests.test_utils import domain, username, password
+from tests.test_utils import domain, username, password, password_md4
 
 
 class TestRequestsNtlm(unittest.TestCase):
@@ -16,7 +14,7 @@ class TestRequestsNtlm(unittest.TestCase):
         self.test_server_username   = '%s\\%s' % (domain, username)
         self.test_server_password   = password
         self.auth_types = ['ntlm', 'negotiate', 'both']
-        self.hash = hashlib.new('md4', password.encode('utf-16le')).hexdigest()
+        self.hash = password_md4
 
     def test_requests_ntlm(self):
         for auth_type in self.auth_types:
@@ -84,7 +82,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = '2334B8476CBF4E6DFC766A5D5A30D6649C01BAE1662A5C3A130' \
                         '2A968D7C6B0F6'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha1(self):
         cert_der = b'MIIDGzCCAgOgAwIBAgIQJg/Mf5sR55xApJRK+kabbTANBgkqhkiG9w0' \
@@ -111,7 +109,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = '14CFE8E4B332B20A343FC840B18F9F6F78926AFE7EC3E7B8E28' \
                         '969619B1E8F3E'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha256(self):
         cert_der = b'MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0' \
@@ -138,7 +136,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = '996F3EEA812C1870E30549FF9B86CD87A890B6D8DFDF4A81BEF' \
                         '9675970DADB26'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha384(self):
         cert_der = b'MIIDGzCCAgOgAwIBAgIQEmj1prSSQYRL2zYBEjsm5jANBgkqhkiG9w0' \
@@ -165,7 +163,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = '34F303C995286F4B214A9BA6435B69B51ECF3758EABC2A14D7A' \
                         '43FD237DC2B1A1AD9111C5C965E107507CB4198C09FEC'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha512(self):
         cert_der = b'MIIDGzCCAgOgAwIBAgIQUDHcKGevZohJV+TkIIYC1DANBgkqhkiG9w0' \
@@ -193,7 +191,7 @@ class TestCertificateHash(unittest.TestCase):
                         '00544E1AD2B76FF25CFBE69B1C4E630C3BB0207DF11314C6738' \
                         'BCAED7E071D7BFBF2C9DFAB85D'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha1(self):
         cert_der = b'MIIBjjCCATSgAwIBAgIQRCJw7nbtvJ5F8wikRmwgizAJBgcqhkjOPQQ' \
@@ -210,7 +208,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = '1EC9AD46DEE9340E4503CFFDB5CD810CB26B778F46BE95D5EAF' \
                         '999DCB1C45EDA'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha256(self):
         cert_der = b'MIIBjzCCATWgAwIBAgIQeNQTxkMgq4BF9tKogIGXUTAKBggqhkjOPQQ' \
@@ -227,7 +225,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = 'FECF1B2585449990D9E3B2C92D3F597EC8354E124EDA751D948' \
                         '37C2C89A2C155'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha384(self):
         cert_der = b'MIIBjzCCATWgAwIBAgIQcO3/jALdQ6BOAoaoseLSCjAKBggqhkjOPQQ' \
@@ -244,7 +242,7 @@ class TestCertificateHash(unittest.TestCase):
         expected_hash = 'D2987AD8F20E8316A831261B74EF7B3E55155D0922E07FFE546' \
                         '20806982B68A73A5E3C478BAA5E7714135CB26D980749'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha512(self):
         cert_der = b'MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ' \
@@ -262,7 +260,7 @@ class TestCertificateHash(unittest.TestCase):
                         'F19A5BD8F0B2FAAC861855FBB63A221CC46FC1E226A072411AF' \
                         '175DDE479281E006878B348059'
         actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
-        assert actual_hash == expected_hash
+        assert actual_hash == base64.b16decode(expected_hash)
 
     def test_invalid_signature_algorithm(self):
         # Manually edited from test_ecdsa_sha512 to change the OID to '1.2.840.10045.4.3.5'

--- a/tests/unit/test_requests_ntlm.py
+++ b/tests/unit/test_requests_ntlm.py
@@ -42,46 +42,6 @@ class TestRequestsNtlm(unittest.TestCase):
             self.assertTrue(res.history[0].request is not res.history[1].request)
             self.assertTrue(res.history[0].request is not res.request)
 
-    def test_username_parse_backslash(self):
-        test_user = 'domain\\user'
-        expected_domain = 'DOMAIN'
-        expected_user = 'user'
-
-        context = requests_ntlm.HttpNtlmAuth(test_user, 'pass')
-
-        actual_domain = context.domain
-        actual_user = context.username
-
-        assert actual_domain == expected_domain
-        assert actual_user == expected_user
-
-    def test_username_parse_at(self):
-        test_user = 'user@domain.com'
-        # UPN format should not be split, since "stuff after @" not always == domain 
-        # (eg, email address with alt UPN suffix)
-        expected_domain = ''
-        expected_user = 'user@domain.com'
-
-        context = requests_ntlm.HttpNtlmAuth(test_user, 'pass')
-
-        actual_domain = context.domain
-        actual_user = context.username
-
-        assert actual_domain == expected_domain
-        assert actual_user == expected_user
-
-    def test_username_parse_no_domain(self):
-        test_user = 'user'
-        expected_domain = ''
-        expected_user = 'user'
-
-        context = requests_ntlm.HttpNtlmAuth(test_user, 'pass')
-
-        actual_domain = context.domain
-        actual_user = context.username
-
-        assert actual_domain == expected_domain
-        assert actual_user == expected_user
 
 class TestCertificateHash(unittest.TestCase):
 


### PR DESCRIPTION
The ntlm_auth library is deprecated in favour of pyspnego. This commit
migrates to this library, patching some methods to ensure dependent code
will continue to work.