### PR TITLE
Fix AttributeError: module 'spnego' has no attribute 'ContextProxy'

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -14,7 +14,7 @@ import spnego
 class ShimSessionSecurity:
     """Shim used for backwards compatibility with ntlm-auth."""
 
-    def __init__(self, context: spnego.ContextProxy) -> None:
+    def __init__(self, context: spnego._context.ContextProxy) -> None:
         self._context = context
 
     def wrap(self, message) -> t.Tuple[bytes, bytes]:


### PR DESCRIPTION
This pull request Fixes AttributeError: module 'spnego' has no attribute 'ContextProxy'

fix #133 