### PR TITLE
Fix type annotation problem by setting correct pyspnego min version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,5 @@ classifiers =
 python_requires = >= 3.7
 install_requires =
     cryptography >= 1.3
-    pyspnego >= 0.1.6
+    pyspnego >= 0.4.0
     requests >= 2.0.0


### PR DESCRIPTION
The `ContextProxy` object was only exposed directly in pyspnego 0.4.0 yet our minimum version is older than that. This ensures requests-ntlm has the correct version installed and not an older one.

Fixes: #133 