### PR TITLE
Throw an exception in case of access denied

### DIFF
--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -138,18 +138,17 @@ class HttpNtlmAuth(AuthBase):
 
         auth_strip = auth_type + " "
 
-        challenges = [
-            s
-            for s in (val.lstrip() for val in auth_header_value.split(","))
-            if s.startswith(auth_strip)
-        ]
-
-        if not challenges:
-            raise AccessDenied("Access denied")
-
         ntlm_header_value = next(
-            challenges
+            (
+                s
+                for s in (val.lstrip() for val in auth_header_value.split(","))
+                if s.startswith(auth_strip)
+            ),
+            None
         ).strip()
+        
+        if not ntlm_header_value:
+            raise PermissionError("Access denied: Server did not respond with NTLM challenge token")
 
         # Parse the challenge in the ntlm context and perform
         # the second step of authentication

--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -11,10 +11,6 @@ from requests.packages.urllib3.response import HTTPResponse
 import spnego
 
 
-class AccessDenied(Exception):
-    pass
-
-
 class ShimSessionSecurity:
     """Shim used for backwards compatibility with ntlm-auth."""
 
@@ -140,13 +136,13 @@ class HttpNtlmAuth(AuthBase):
 
         ntlm_header_value = next(
             (
-                s
+                s.strip()
                 for s in (val.lstrip() for val in auth_header_value.split(","))
                 if s.startswith(auth_strip)
             ),
-            None
-        ).strip()
-        
+            None,
+        )
+
         if not ntlm_header_value:
             raise PermissionError("Access denied: Server did not respond with NTLM challenge token")
 

--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -11,6 +11,10 @@ from requests.packages.urllib3.response import HTTPResponse
 import spnego
 
 
+class AccessDenied(Exception):
+    pass
+
+
 class ShimSessionSecurity:
     """Shim used for backwards compatibility with ntlm-auth."""
 
@@ -134,10 +138,17 @@ class HttpNtlmAuth(AuthBase):
 
         auth_strip = auth_type + " "
 
-        ntlm_header_value = next(
+        challenges = [
             s
             for s in (val.lstrip() for val in auth_header_value.split(","))
             if s.startswith(auth_strip)
+        ]
+
+        if not challenges:
+            raise AccessDenied("Access denied")
+
+        ntlm_header_value = next(
+            challenges
         ).strip()
 
         # Parse the challenge in the ntlm context and perform

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,7 +18,11 @@ def negotiate_auth():
 def negotiate_and_ntlm_auth():
     return get_auth_response('NTLM', advertise_nego_and_ntlm=True)
 
-def get_auth_response(auth_type, advertise_nego_and_ntlm=False):
+@app.route("/no_challenge")
+def no_challenge():
+    return get_auth_response('Negotiate', no_challenge=True)
+
+def get_auth_response(auth_type, advertise_nego_and_ntlm=False, no_challenge=False):
     # Get the actual header that is returned by requests_ntlm
     actual_header = request.headers.get('Authorization', '')
 
@@ -43,7 +47,11 @@ def get_auth_response(auth_type, advertise_nego_and_ntlm=False):
         # Get the NTLM version number (bytes 9 - 12)
         message_type = struct.unpack("<I", msg[8:12])[0]
 
-        if message_type == negotiate_message_type:
+        if no_challenge:
+            response_headers = {'WWW-Authenticate': auth_type}
+            response = "access denied"
+            status_code = 401
+        elif message_type == negotiate_message_type:
             # Initial NTLM message from client, attach challenge token
             challenge_response = ('TlRMTVNTUAACAAAAAwAMADgAAAAzgoriASNFZ4mrze8AAAA'
                                   'AAAAAACQAJABEAAAABgBwFwAAAA9TAGUAcgB2AGUAcgACAA'

--- a/tests/unit/test_requests_ntlm.py
+++ b/tests/unit/test_requests_ntlm.py
@@ -54,6 +54,20 @@ class TestRequestsNtlm(unittest.TestCase):
             self.assertTrue(res.history[0].request is not res.history[1].request)
             self.assertTrue(res.history[0].request is not res.request)
 
+    def test_permissions_denied(self):
+        auth = requests_ntlm.HttpNtlmAuth(
+            self.test_server_username,
+            self.test_server_password,
+        )
+
+        with self.assertRaises(PermissionError) as e:
+            requests.get(
+                url=f"{self.test_server_url}no_challenge",
+                auth=auth,
+            )
+
+        self.assertEqual(str(e.exception), "Access denied: Server did not respond with NTLM challenge token")
+
 
 class TestCertificateHash(unittest.TestCase):
 


### PR DESCRIPTION
I just had to debug an issue which was caused by insufficient permissions.

[This line](https://github.com/requests/requests-ntlm/blob/b80f1c72eb3fd974b2576c303c49b2048ef9e80d/requests_ntlm/requests_ntlm.py#L137) was raising `StopIteration` because the iterable was empty. It was empty because the `WWW-Authenticate` header of `response2` only contained the string `Negotiate`. There was no challenge. The status code was 401 and in the body it contained a HTML message saying I had insufficient permission or invalid credentials (which is true).

I'm not an expert in that protocol, but it seems that if there is no challenge in the second response, we can assume that access was denied and throw an exception accordingly.