### PR TITLE
Add type annotation and black/isort checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: '3.7'
         - python-version: '3.8'
         - python-version: '3.9'
         - python-version: '3.10'
@@ -46,6 +45,10 @@ jobs:
         python -m pip install -U pip setuptools
         python -m pip install .
         python -m pip install -r requirements.txt
+
+        python -m black . --check
+        python -m isort . --check-only
+        python -m mypy .
 
         python -m tests.test_server &
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
+include CONTRIBUTORS.rst
 include LICENSE
+include requirements.txt
+
+recursive-include tests *
+recursive-exclude tests *.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,37 @@ requires = [
     "setuptools >= 42.0.0",  # Supports license_files
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+exclude = '''
+/(
+    \.git
+    | \.venv
+    | build
+    | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+exclude = "setup\\.py|build/|tests/"
+mypy_path = "$MYPY_CONFIG_FILE_DIR"
+python_version = "3.8"
+show_error_codes = true
+show_column_numbers = true
+disallow_any_unimported = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_reexport = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = "requests.packages.urllib3.*"
+ignore_missing_imports = true

--- a/requests_ntlm/__init__.py
+++ b/requests_ntlm/__init__.py
@@ -1,3 +1,3 @@
 from .requests_ntlm import HttpNtlmAuth
 
-__all__ = ('HttpNtlmAuth',)
+__all__ = ("HttpNtlmAuth",)

--- a/requests_ntlm/requests_ntlm.py
+++ b/requests_ntlm/requests_ntlm.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-import warnings
 import base64
 import typing as t
-
+import warnings
 from urllib.parse import urlparse
 
 import requests
 import spnego
-
 from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
-from cryptography.exceptions import UnsupportedAlgorithm
 from requests.auth import AuthBase
 from requests.packages.urllib3.response import HTTPResponse
 
@@ -170,7 +168,9 @@ class HttpNtlmAuth(AuthBase):
         )
 
         if not ntlm_header_value:
-            raise PermissionError("Access denied: Server did not respond with NTLM challenge token")
+            raise PermissionError(
+                "Access denied: Server did not respond with NTLM challenge token"
+            )
 
         # Parse the challenge in the ntlm context and perform
         # the second step of authentication

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
+black == 24.4.2
+isort == 5.13.2
 requests>=2.0.0
 pyspnego
 cryptography>=1.3
 flask
+mypy == 1.10.0
 pytest
 pytest-cov
+types-requests
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Intended Audience :: Developers
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -22,8 +21,11 @@ classifiers =
     License :: OSI Approved :: ISC License (ISCL)
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
     cryptography >= 1.3
     pyspnego >= 0.4.0
     requests >= 2.0.0
+
+[tools.setuptools.package-data]
+"requests_ntlm" = ["py.typed"]

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,4 +1,5 @@
 import requests
+
 import requests_ntlm
 
 """
@@ -7,18 +8,19 @@ it can only be run locally. The script setup_iis.ps1 can set up an IIS server
 with the 4 scenarios tested below if you wish to run a sanity check
 """
 
-username = '.\\User'
-password = 'Password01'
-http_with_cbt = 'http://127.0.0.1:81/contents.txt'
-http_without_cbt = 'http://127.0.0.1:82/contents.txt'
-https_with_cbt = 'https://127.0.0.1:441/contents.txt'
-https_without_cbt = 'https://127.0.0.1:442/contents.txt'
-expected = 'contents'
+username = ".\\User"
+password = "Password01"
+http_with_cbt = "http://127.0.0.1:81/contents.txt"
+http_without_cbt = "http://127.0.0.1:82/contents.txt"
+https_with_cbt = "https://127.0.0.1:441/contents.txt"
+https_without_cbt = "https://127.0.0.1:442/contents.txt"
+expected = "contents"
 
-class Test_Functional():
+
+class Test_Functional:
     def test_ntlm_http_with_cbt(self):
         actual = send_request(http_with_cbt, username, password)
-        actual_content = actual.content.decode('utf-8')
+        actual_content = actual.content.decode("utf-8")
         actual_code = actual.status_code
 
         assert actual_code == 200
@@ -26,7 +28,7 @@ class Test_Functional():
 
     def test_ntlm_http_without_cbt(self):
         actual = send_request(http_without_cbt, username, password)
-        actual_content = actual.content.decode('utf-8')
+        actual_content = actual.content.decode("utf-8")
         actual_code = actual.status_code
 
         assert actual_code == 200
@@ -34,7 +36,7 @@ class Test_Functional():
 
     def test_ntlm_https_with_cbt(self):
         actual = send_request(https_with_cbt, username, password)
-        actual_content = actual.content.decode('utf-8')
+        actual_content = actual.content.decode("utf-8")
         actual_code = actual.status_code
 
         assert actual_code == 200
@@ -42,11 +44,12 @@ class Test_Functional():
 
     def test_ntlm_https_without_cbt(self):
         actual = send_request(https_without_cbt, username, password)
-        actual_content = actual.content.decode('utf-8')
+        actual_content = actual.content.decode("utf-8")
         actual_code = actual.status_code
 
         assert actual_code == 200
         assert actual_content == expected
+
 
 def send_request(url, username, password):
     """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,73 +1,90 @@
 import base64
 import struct
 
-from flask import Flask,request
-from tests.test_utils import domain, username, password
+from flask import Flask, request
+
+from tests.test_utils import domain, password, username
 
 app = Flask(__name__)
 
+
 @app.route("/ntlm")
 def ntlm_auth():
-    return get_auth_response('NTLM')
+    return get_auth_response("NTLM")
+
 
 @app.route("/negotiate")
 def negotiate_auth():
-    return get_auth_response('Negotiate')
+    return get_auth_response("Negotiate")
+
 
 @app.route("/both")
 def negotiate_and_ntlm_auth():
-    return get_auth_response('NTLM', advertise_nego_and_ntlm=True)
+    return get_auth_response("NTLM", advertise_nego_and_ntlm=True)
+
 
 @app.route("/no_challenge")
 def no_challenge():
-    return get_auth_response('Negotiate', no_challenge=True)
+    return get_auth_response("Negotiate", no_challenge=True)
+
 
 def get_auth_response(auth_type, advertise_nego_and_ntlm=False, no_challenge=False):
     # Get the actual header that is returned by requests_ntlm
-    actual_header = request.headers.get('Authorization', '')
+    actual_header = request.headers.get("Authorization", "")
 
     # Check what the message type is from the header
-    if actual_header == '':
+    if actual_header == "":
         # This is the initial connection, need to return a 401
-        response_headers = {'WWW-Authenticate': auth_type if not advertise_nego_and_ntlm else 'Negotiate, NTLM'}
+        response_headers = {
+            "WWW-Authenticate": (
+                auth_type if not advertise_nego_and_ntlm else "Negotiate, NTLM"
+            )
+        }
         status_code = 401
         response = "auth with '%s\\%s':'%s'" % (domain, username, password)
     else:
         # Set human readable names for message types
         # see https://msdn.microsoft.com/en-us/library/cc236639.aspx for more details
-        expected_signature = b'NTLMSSP\x00'
+        expected_signature = b"NTLMSSP\x00"
         negotiate_message_type = 1
         authenticate_message_type = 3
 
-        msg = base64.b64decode(actual_header[len(auth_type):])
+        msg = base64.b64decode(actual_header[len(auth_type) :])
         signature = msg[0:8]
         if signature != expected_signature:
-            raise ValueError("Mismatch on NTLM message signature, expecting: %s, actual: %s" % (expected_signature,
-                                                                                                signature))
+            raise ValueError(
+                "Mismatch on NTLM message signature, expecting: %s, actual: %s"
+                % (expected_signature, signature)
+            )
         # Get the NTLM version number (bytes 9 - 12)
         message_type = struct.unpack("<I", msg[8:12])[0]
 
         if no_challenge:
-            response_headers = {'WWW-Authenticate': auth_type}
+            response_headers = {"WWW-Authenticate": auth_type}
             response = "access denied"
             status_code = 401
         elif message_type == negotiate_message_type:
             # Initial NTLM message from client, attach challenge token
-            challenge_response = ('TlRMTVNTUAACAAAAAwAMADgAAAAzgoriASNFZ4mrze8AAAA'
-                                  'AAAAAACQAJABEAAAABgBwFwAAAA9TAGUAcgB2AGUAcgACAA'
-                                  'wARABvAG0AYQBpAG4AAQAMAFMAZQByAHYAZQByAAAAAAA=')
-            challenge_header = auth_type + ' ' + challenge_response
-            response_headers = {'WWW-Authenticate': challenge_header}
+            challenge_response = (
+                "TlRMTVNTUAACAAAAAwAMADgAAAAzgoriASNFZ4mrze8AAAA"
+                "AAAAAACQAJABEAAAABgBwFwAAAA9TAGUAcgB2AGUAcgACAA"
+                "wARABvAG0AYQBpAG4AAQAMAFMAZQByAHYAZQByAAAAAAA="
+            )
+            challenge_header = auth_type + " " + challenge_response
+            response_headers = {"WWW-Authenticate": challenge_header}
             response = "auth with '%s\\%s':'%s'" % (domain, username, password)
             status_code = 401
         elif message_type == authenticate_message_type:
             # Received final NTLM message, return 200
             response_headers = {}
             status_code = 200
-            response = 'authed'
+            response = "authed"
         else:
             # Should only ever receive a negotiate (1) or auth (3) message from requests_ntlm
-            raise ValueError("Mismatch on NTLM message type, expecting: 1 or 3, actual: %d" % message_type)
+            raise ValueError(
+                "Mismatch on NTLM message type, expecting: 1 or 3, actual: %d"
+                % message_type
+            )
 
     return response, status_code, response_headers
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # Default variables used for the ntlm_context
-username = 'username'
-domain = 'domain'
-password = 'password'
+username = "username"
+domain = "domain"
+password = "password"
 
 # Genearated online as hashlib.md4 may not be available anymore
-password_md4 = '8a9d093f14f8701df17732b2bb182c74'
+password_md4 = "8a9d093f14f8701df17732b2bb182c74"

--- a/tests/unit/test_requests_ntlm.py
+++ b/tests/unit/test_requests_ntlm.py
@@ -1,55 +1,64 @@
 import base64
 import unittest
-import requests
-import requests_ntlm
 import warnings
 
-from tests.test_utils import domain, username, password, password_md4
+import requests
+
+import requests_ntlm
+from tests.test_utils import domain, password, password_md4, username
 
 
 class TestRequestsNtlm(unittest.TestCase):
 
     def setUp(self):
-        self.test_server_url        = 'http://localhost:5000/'
-        self.test_server_username   = '%s\\%s' % (domain, username)
-        self.test_server_password   = password
-        self.auth_types = ['ntlm', 'negotiate', 'both']
+        self.test_server_url = "http://localhost:5000/"
+        self.test_server_username = "%s\\%s" % (domain, username)
+        self.test_server_password = password
+        self.auth_types = ["ntlm", "negotiate", "both"]
         self.hash = password_md4
 
     def test_requests_ntlm(self):
         for auth_type in self.auth_types:
-            res = requests.get(\
-                url  = self.test_server_url + auth_type,\
-                auth = requests_ntlm.HttpNtlmAuth(
-                    self.test_server_username,\
-                    self.test_server_password))
+            res = requests.get(
+                url=self.test_server_url + auth_type,
+                auth=requests_ntlm.HttpNtlmAuth(
+                    self.test_server_username, self.test_server_password
+                ),
+            )
 
-            self.assertEqual(res.status_code,200, msg='auth_type ' + auth_type)
+            self.assertEqual(res.status_code, 200, msg="auth_type " + auth_type)
 
     def test_requests_ntlm_hash(self):
         # Test authenticating using an NTLM hash
         for auth_type in self.auth_types:
-            res = requests.get(\
-                url  = self.test_server_url + auth_type,\
-                auth = requests_ntlm.HttpNtlmAuth(
-                    self.test_server_username,\
-                    "0" * 32 + ":" + self.hash))
+            res = requests.get(
+                url=self.test_server_url + auth_type,
+                auth=requests_ntlm.HttpNtlmAuth(
+                    self.test_server_username, "0" * 32 + ":" + self.hash
+                ),
+            )
 
-            self.assertEqual(res.status_code,200, msg='auth_type ' + auth_type)
+            self.assertEqual(res.status_code, 200, msg="auth_type " + auth_type)
 
     def test_history_is_preserved(self):
         for auth_type in self.auth_types:
-            res = requests.get(url=self.test_server_url + auth_type,
-                               auth=requests_ntlm.HttpNtlmAuth(self.test_server_username,
-                                                               self.test_server_password))
+            res = requests.get(
+                url=self.test_server_url + auth_type,
+                auth=requests_ntlm.HttpNtlmAuth(
+                    self.test_server_username, self.test_server_password
+                ),
+            )
 
             self.assertEqual(len(res.history), 2)
 
     def test_new_requests_are_used(self):
         for auth_type in self.auth_types:
-            res = requests.get(url=self.test_server_url + auth_type,
-                               auth=requests_ntlm.HttpNtlmAuth(self.test_server_username,
-                                                               self.test_server_password))
+            res = requests.get(
+                url=self.test_server_url + auth_type,
+                auth=requests_ntlm.HttpNtlmAuth(
+                    self.test_server_username, self.test_server_password
+                ),
+            )
 
             self.assertTrue(res.history[0].request is not res.history[1].request)
             self.assertTrue(res.history[0].request is not res.request)
@@ -66,235 +75,293 @@ class TestRequestsNtlm(unittest.TestCase):
                 auth=auth,
             )
 
-        self.assertEqual(str(e.exception), "Access denied: Server did not respond with NTLM challenge token")
+        self.assertEqual(
+            str(e.exception),
+            "Access denied: Server did not respond with NTLM challenge token",
+        )
 
 
 class TestCertificateHash(unittest.TestCase):
 
     def test_rsa_md5(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQJzshhViMG5hLHIJHxa+TcTANBgkqhkiG9w0' \
-                   b'BAQQFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN9N5GAzI7uq' \
-                   b'AVlI6vUqhY5+EZWCWWGRwR3FT2DEXE5++AiJxXO0i0ZfAkLu7UggtBe' \
-                   b'QwVNkaPD27EYzVUhy1iDo37BrFcLNpfjsjj8wVjaSmQmqvLvrvEh/BT' \
-                   b'C5SBgDrk2+hiMh9PrpJoB3QAMDinz5aW0rEXMKitPBBiADrczyYrliF' \
-                   b'AlEU6pTlKEKDUAeP7dKOBlDbCYvBxKnR3ddVH74I5T2SmNBq5gzkbKP' \
-                   b'nlCXdHLZSh74USu93rKDZQF8YzdTO5dcBreJDJsntyj1o49w9WCt6M7' \
-                   b'+pg6vKvE+tRbpCm7kXq5B9PDi42Nb6//MzNaMYf9V7v5MHapvVSv3+y' \
-                   b'sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBTh4L2Clr9ber6yfY3JFS3wiECL4DANBgkqhkiG9w0BAQQ' \
-                   b'FAAOCAQEA0JK/SL7SP9/nvqWp52vnsxVefTFehThle5DLzagmms/9gu' \
-                   b'oSE2I9XkQIttFMprPosaIZWt7WP42uGcZmoZOzU8kFFYJMfg9Ovyca+' \
-                   b'gnG28jDUMF1E74KrC7uynJiQJ4vPy8ne7F3XJ592LsNJmK577l42gAW' \
-                   b'u08p3TvEJFNHy2dBk/IwZp0HIPr9+JcPf7v0uL6lK930xHJHP56XLzN' \
-                   b'YG8vCMpJFR7wVZp3rXkJQUy3GxyHPJPjS8S43I9j+PoyioWIMEotq2+' \
-                   b'q0IpXU/KeNFkdGV6VPCmzhykijExOMwO6doUzIUM8orv9jYLHXYC+i6' \
-                   b'IFKSb6runxF1MAik+GCSA=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQJzshhViMG5hLHIJHxa+TcTANBgkqhkiG9w0"
+            b"BAQQFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN9N5GAzI7uq"
+            b"AVlI6vUqhY5+EZWCWWGRwR3FT2DEXE5++AiJxXO0i0ZfAkLu7UggtBe"
+            b"QwVNkaPD27EYzVUhy1iDo37BrFcLNpfjsjj8wVjaSmQmqvLvrvEh/BT"
+            b"C5SBgDrk2+hiMh9PrpJoB3QAMDinz5aW0rEXMKitPBBiADrczyYrliF"
+            b"AlEU6pTlKEKDUAeP7dKOBlDbCYvBxKnR3ddVH74I5T2SmNBq5gzkbKP"
+            b"nlCXdHLZSh74USu93rKDZQF8YzdTO5dcBreJDJsntyj1o49w9WCt6M7"
+            b"+pg6vKvE+tRbpCm7kXq5B9PDi42Nb6//MzNaMYf9V7v5MHapvVSv3+y"
+            b"sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBTh4L2Clr9ber6yfY3JFS3wiECL4DANBgkqhkiG9w0BAQQ"
+            b"FAAOCAQEA0JK/SL7SP9/nvqWp52vnsxVefTFehThle5DLzagmms/9gu"
+            b"oSE2I9XkQIttFMprPosaIZWt7WP42uGcZmoZOzU8kFFYJMfg9Ovyca+"
+            b"gnG28jDUMF1E74KrC7uynJiQJ4vPy8ne7F3XJ592LsNJmK577l42gAW"
+            b"u08p3TvEJFNHy2dBk/IwZp0HIPr9+JcPf7v0uL6lK930xHJHP56XLzN"
+            b"YG8vCMpJFR7wVZp3rXkJQUy3GxyHPJPjS8S43I9j+PoyioWIMEotq2+"
+            b"q0IpXU/KeNFkdGV6VPCmzhykijExOMwO6doUzIUM8orv9jYLHXYC+i6"
+            b"IFKSb6runxF1MAik+GCSA=="
+        )
 
-        expected_hash = '2334B8476CBF4E6DFC766A5D5A30D6649C01BAE1662A5C3A130' \
-                        '2A968D7C6B0F6'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "2334B8476CBF4E6DFC766A5D5A30D6649C01BAE1662A5C3A130" "2A968D7C6B0F6"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha1(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQJg/Mf5sR55xApJRK+kabbTANBgkqhkiG9w0' \
-                   b'BAQUFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALPKwYikjbzL' \
-                   b'Lo6JtS6cyytdMMjSrggDoTnRUKauC5/izoYJd+2YVR5YqnluBJZpoFp' \
-                   b'hkCgFFohUOU7qUsI1SkuGnjI8RmWTrrDsSy62BrfX+AXkoPlXo6IpHz' \
-                   b'HaEPxjHJdUACpn8QVWTPmdAhwTwQkeUutrm3EOVnKPX4bafNYeAyj7/' \
-                   b'AGEplgibuXT4/ehbzGKOkRN3ds/pZuf0xc4Q2+gtXn20tQIUt7t6iwh' \
-                   b'nEWjIgopFL/hX/r5q5MpF6stc1XgIwJjEzqMp76w/HUQVqaYneU4qSG' \
-                   b'f90ANK/TQ3aDbUNtMC/ULtIfHqHIW4POuBYXaWBsqalJL2VL3YYkKTU' \
-                   b'sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBS1jgojcjPu9vqeP1uSKuiIonGwAjANBgkqhkiG9w0BAQU' \
-                   b'FAAOCAQEAKjHL6k5Dv/Zb7dvbYEZyx0wVhjHkCTpT3xstI3+TjfAFsu' \
-                   b'3zMmyFqFqzmr4pWZ/rHc3ObD4pEa24kP9hfB8nmr8oHMLebGmvkzh5h' \
-                   b'0GYc4dIH7Ky1yfQN51hi7/X5iN7jnnBoCJTTlgeBVYDOEBXhfXi3cLT' \
-                   b'u3d7nz2heyNq07gFP8iN7MfqdPZndVDYY82imLgsgar9w5d+fvnYM+k' \
-                   b'XWItNNCUH18M26Obp4Es/Qogo/E70uqkMHost2D+tww/7woXi36X3w/' \
-                   b'D2yBDyrJMJKZLmDgfpNIeCimncTOzi2IhzqJiOY/4XPsVN/Xqv0/dzG' \
-                   b'TDdI11kPLq4EiwxvPanCg=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQJg/Mf5sR55xApJRK+kabbTANBgkqhkiG9w0"
+            b"BAQUFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxNloXDTE4MDUzMDA4MjMxNlowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALPKwYikjbzL"
+            b"Lo6JtS6cyytdMMjSrggDoTnRUKauC5/izoYJd+2YVR5YqnluBJZpoFp"
+            b"hkCgFFohUOU7qUsI1SkuGnjI8RmWTrrDsSy62BrfX+AXkoPlXo6IpHz"
+            b"HaEPxjHJdUACpn8QVWTPmdAhwTwQkeUutrm3EOVnKPX4bafNYeAyj7/"
+            b"AGEplgibuXT4/ehbzGKOkRN3ds/pZuf0xc4Q2+gtXn20tQIUt7t6iwh"
+            b"nEWjIgopFL/hX/r5q5MpF6stc1XgIwJjEzqMp76w/HUQVqaYneU4qSG"
+            b"f90ANK/TQ3aDbUNtMC/ULtIfHqHIW4POuBYXaWBsqalJL2VL3YYkKTU"
+            b"sCAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBS1jgojcjPu9vqeP1uSKuiIonGwAjANBgkqhkiG9w0BAQU"
+            b"FAAOCAQEAKjHL6k5Dv/Zb7dvbYEZyx0wVhjHkCTpT3xstI3+TjfAFsu"
+            b"3zMmyFqFqzmr4pWZ/rHc3ObD4pEa24kP9hfB8nmr8oHMLebGmvkzh5h"
+            b"0GYc4dIH7Ky1yfQN51hi7/X5iN7jnnBoCJTTlgeBVYDOEBXhfXi3cLT"
+            b"u3d7nz2heyNq07gFP8iN7MfqdPZndVDYY82imLgsgar9w5d+fvnYM+k"
+            b"XWItNNCUH18M26Obp4Es/Qogo/E70uqkMHost2D+tww/7woXi36X3w/"
+            b"D2yBDyrJMJKZLmDgfpNIeCimncTOzi2IhzqJiOY/4XPsVN/Xqv0/dzG"
+            b"TDdI11kPLq4EiwxvPanCg=="
+        )
 
-        expected_hash = '14CFE8E4B332B20A343FC840B18F9F6F78926AFE7EC3E7B8E28' \
-                        '969619B1E8F3E'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "14CFE8E4B332B20A343FC840B18F9F6F78926AFE7EC3E7B8E28" "969619B1E8F3E"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha256(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0' \
-                   b'BAQsFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUyNzA5MD' \
-                   b'I0NFoXDTE4MDUyNzA5MjI0NFowFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALIPKM5uykFy' \
-                   b'NmVoLyvPSXGk15ZDqjYi3AbUxVFwCkVImqhefLATit3PkTUYFtAT+TC' \
-                   b'AwK2E4lOu1XHM+Tmp2KIOnq2oUR8qMEvfxYThEf1MHxkctFljFssZ9N' \
-                   b'vASDD4lzw8r0Bhl+E5PhR22Eu1Wago5bvIldojkwG+WBxPQv3ZR546L' \
-                   b'MUZNaBXC0RhuGj5w83lbVz75qM98wvv1ekfZYAP7lrVyHxqCTPDomEU' \
-                   b'I45tQQZHCZl5nRx1fPCyyYfcfqvFlLWD4Q3PZAbnw6mi0MiWJbGYKME' \
-                   b'1XGicjqyn/zM9XKA1t/JzChS2bxf6rsyA9I7ibdRHUxsm1JgKry2jfW' \
-                   b'0CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBQabLGWg1sn7AXPwYPyfE0ER921ZDANBgkqhkiG9w0BAQs' \
-                   b'FAAOCAQEAnRohyl6ZmOsTWCtxOJx5A8yr//NweXKwWWmFQXRmCb4bMC' \
-                   b'xhD4zqLDf5P6RotGV0I/SHvqz+pAtJuwmr+iyAF6WTzo3164LCfnQEu' \
-                   b'psfrrfMkf3txgDwQkA0oPAw3HEwOnR+tzprw3Yg9x6UoZEhi4XqP9AX' \
-                   b'R49jU92KrNXJcPlz5MbkzNo5t9nr2f8q39b5HBjaiBJxzdM1hxqsbfD' \
-                   b'KirTYbkUgPlVOo/NDmopPPb8IX8ubj/XETZG2jixD0zahgcZ1vdr/iZ' \
-                   b'+50WSXKN2TAKBO2fwoK+2/zIWrGRxJTARfQdF+fGKuj+AERIFNh88HW' \
-                   b'xSDYjHQAaFMcfdUpa9GGQ=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQWkeAtqoFg6pNWF7xC4YXhTANBgkqhkiG9w0"
+            b"BAQsFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUyNzA5MD"
+            b"I0NFoXDTE4MDUyNzA5MjI0NFowFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALIPKM5uykFy"
+            b"NmVoLyvPSXGk15ZDqjYi3AbUxVFwCkVImqhefLATit3PkTUYFtAT+TC"
+            b"AwK2E4lOu1XHM+Tmp2KIOnq2oUR8qMEvfxYThEf1MHxkctFljFssZ9N"
+            b"vASDD4lzw8r0Bhl+E5PhR22Eu1Wago5bvIldojkwG+WBxPQv3ZR546L"
+            b"MUZNaBXC0RhuGj5w83lbVz75qM98wvv1ekfZYAP7lrVyHxqCTPDomEU"
+            b"I45tQQZHCZl5nRx1fPCyyYfcfqvFlLWD4Q3PZAbnw6mi0MiWJbGYKME"
+            b"1XGicjqyn/zM9XKA1t/JzChS2bxf6rsyA9I7ibdRHUxsm1JgKry2jfW"
+            b"0CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBQabLGWg1sn7AXPwYPyfE0ER921ZDANBgkqhkiG9w0BAQs"
+            b"FAAOCAQEAnRohyl6ZmOsTWCtxOJx5A8yr//NweXKwWWmFQXRmCb4bMC"
+            b"xhD4zqLDf5P6RotGV0I/SHvqz+pAtJuwmr+iyAF6WTzo3164LCfnQEu"
+            b"psfrrfMkf3txgDwQkA0oPAw3HEwOnR+tzprw3Yg9x6UoZEhi4XqP9AX"
+            b"R49jU92KrNXJcPlz5MbkzNo5t9nr2f8q39b5HBjaiBJxzdM1hxqsbfD"
+            b"KirTYbkUgPlVOo/NDmopPPb8IX8ubj/XETZG2jixD0zahgcZ1vdr/iZ"
+            b"+50WSXKN2TAKBO2fwoK+2/zIWrGRxJTARfQdF+fGKuj+AERIFNh88HW"
+            b"xSDYjHQAaFMcfdUpa9GGQ=="
+        )
 
-        expected_hash = '996F3EEA812C1870E30549FF9B86CD87A890B6D8DFDF4A81BEF' \
-                        '9675970DADB26'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "996F3EEA812C1870E30549FF9B86CD87A890B6D8DFDF4A81BEF" "9675970DADB26"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha384(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQEmj1prSSQYRL2zYBEjsm5jANBgkqhkiG9w0' \
-                   b'BAQwFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKsK5NvHi4xO' \
-                   b'081fRLMmPqKsKaHvXgPRykLA0SmKxpGJHfTAZzxojHVeVwOm87IvQj2' \
-                   b'JUh/yrRwSi5Oqrvqx29l2IC/qQt2xkAQsO51/EWkMQ5OSJsl1MN3NXW' \
-                   b'eRTKVoUuJzBs8XLmeraxQcBPyyLhq+WpMl/Q4ZDn1FrUEZfxV0POXgU' \
-                   b'dI3ApuQNRtJOb6iteBIoQyMlnof0RswBUnkiWCA/+/nzR0j33j47IfL' \
-                   b'nkmU4RtqkBlO13f6+e1GZ4lEcQVI2yZq4Zgu5VVGAFU2lQZ3aEVMTu9' \
-                   b'8HEqD6heyNp2on5G/K/DCrGWYCBiASjnX3wiSz0BYv8f3HhCgIyVKhJ' \
-                   b'8CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBQS/SI61S2UE8xwSgHxbkCTpZXo4TANBgkqhkiG9w0BAQw' \
-                   b'FAAOCAQEAMVV/WMXd9w4jtDfSrIsKaWKGtHtiMPpAJibXmSakBRwLOn' \
-                   b'5ZGXL2bWI/Ac2J2Y7bSzs1im2ifwmEqwzzqnpVKShIkZmtij0LS0SEr' \
-                   b'6Fw5IrK8tD6SH+lMMXUTvp4/lLQlgRCwOWxry/YhQSnuprx8IfSPvil' \
-                   b'kwZ0Ysim4Aa+X5ojlhHpWB53edX+lFrmR1YWValBnQ5DvnDyFyLR6II' \
-                   b'Ialp4vmkzI9e3/eOgSArksizAhpXpC9dxQBiHXdhredN0X+1BVzbgzV' \
-                   b'hQBEwgnAIPa+B68oDILaV0V8hvxrP6jFM4IrKoGS1cq0B+Ns0zkG7ZA' \
-                   b'2Q0W+3nVwSxIr6bd6hw7g=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQEmj1prSSQYRL2zYBEjsm5jANBgkqhkiG9w0"
+            b"BAQwFADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKsK5NvHi4xO"
+            b"081fRLMmPqKsKaHvXgPRykLA0SmKxpGJHfTAZzxojHVeVwOm87IvQj2"
+            b"JUh/yrRwSi5Oqrvqx29l2IC/qQt2xkAQsO51/EWkMQ5OSJsl1MN3NXW"
+            b"eRTKVoUuJzBs8XLmeraxQcBPyyLhq+WpMl/Q4ZDn1FrUEZfxV0POXgU"
+            b"dI3ApuQNRtJOb6iteBIoQyMlnof0RswBUnkiWCA/+/nzR0j33j47IfL"
+            b"nkmU4RtqkBlO13f6+e1GZ4lEcQVI2yZq4Zgu5VVGAFU2lQZ3aEVMTu9"
+            b"8HEqD6heyNp2on5G/K/DCrGWYCBiASjnX3wiSz0BYv8f3HhCgIyVKhJ"
+            b"8CAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBQS/SI61S2UE8xwSgHxbkCTpZXo4TANBgkqhkiG9w0BAQw"
+            b"FAAOCAQEAMVV/WMXd9w4jtDfSrIsKaWKGtHtiMPpAJibXmSakBRwLOn"
+            b"5ZGXL2bWI/Ac2J2Y7bSzs1im2ifwmEqwzzqnpVKShIkZmtij0LS0SEr"
+            b"6Fw5IrK8tD6SH+lMMXUTvp4/lLQlgRCwOWxry/YhQSnuprx8IfSPvil"
+            b"kwZ0Ysim4Aa+X5ojlhHpWB53edX+lFrmR1YWValBnQ5DvnDyFyLR6II"
+            b"Ialp4vmkzI9e3/eOgSArksizAhpXpC9dxQBiHXdhredN0X+1BVzbgzV"
+            b"hQBEwgnAIPa+B68oDILaV0V8hvxrP6jFM4IrKoGS1cq0B+Ns0zkG7ZA"
+            b"2Q0W+3nVwSxIr6bd6hw7g=="
+        )
 
-        expected_hash = '34F303C995286F4B214A9BA6435B69B51ECF3758EABC2A14D7A' \
-                        '43FD237DC2B1A1AD9111C5C965E107507CB4198C09FEC'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "34F303C995286F4B214A9BA6435B69B51ECF3758EABC2A14D7A"
+            "43FD237DC2B1A1AD9111C5C965E107507CB4198C09FEC"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_rsa_sha512(self):
-        cert_der = b'MIIDGzCCAgOgAwIBAgIQUDHcKGevZohJV+TkIIYC1DANBgkqhkiG9w0' \
-                   b'BAQ0FADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD' \
-                   b'MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN' \
-                   b'jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKr9bo/XXvHt' \
-                   b'D6Qnhb1wyLg9lDQxxe/enH49LQihtVTZMwGf2010h81QrRUe/bkHTvw' \
-                   b'K22s2lqj3fUpGxtEbYFWLAHxv6IFnIKd+Zi1zaCPGfas9ekqCSj3vZQ' \
-                   b'j7lCJVGUGuuqnSDvsed6g2Pz/g6mJUa+TzjxN+8wU5oj5YVUK+aing1' \
-                   b'zPSA2MDCfx3+YzjxVwNoGixOz6Yx9ijT4pUsAYQAf1o9R+6W1/IpGgu' \
-                   b'oax714QILT9heqIowwlHzlUZc1UAYs0/JA4CbDZaw9hlJyzMqe/aE46' \
-                   b'efqPDOpO3vCpOSRcSyzh02WijPvEEaPejQRWg8RX93othZ615MT7dqp' \
-                   b'ECAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA' \
-                   b'QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G' \
-                   b'A1UdDgQWBBTgod3R6vejt6kOASAApA19xIG6kTANBgkqhkiG9w0BAQ0' \
-                   b'FAAOCAQEAVfz0okK2bh3OQE8cWNbJ5PjJRSAJEqVUvYaTlS0Nqkyuaj' \
-                   b'gicP3hb/pF8FvaVaB6r7LqgBxyW5NNL1xwdNLt60M2zaULL6Fhm1vzM' \
-                   b'sSMc2ynkyN4++ODwii674YcQAnkUh+ZGIx+CTdZBWJfVM9dZb7QjgBT' \
-                   b'nVukeFwN2EOOBSpiQSBpcoeJEEAq9csDVRhEfcB8Wtz7TTItgOVsilY' \
-                   b'dQY56ON5XszjCki6UA3GwdQbBEHjWF2WERqXWrojrSSNOYDvxM5mrEx' \
-                   b'sG1npzUTsaIr9w8ty1beh/2aToCMREvpiPFOXnVV/ovHMU1lFQTNeQ0' \
-                   b'OI7elR0nJ0peai30eMpQQ=='
+        cert_der = (
+            b"MIIDGzCCAgOgAwIBAgIQUDHcKGevZohJV+TkIIYC1DANBgkqhkiG9w0"
+            b"BAQ0FADAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MD"
+            b"MxN1oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxN"
+            b"jCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKr9bo/XXvHt"
+            b"D6Qnhb1wyLg9lDQxxe/enH49LQihtVTZMwGf2010h81QrRUe/bkHTvw"
+            b"K22s2lqj3fUpGxtEbYFWLAHxv6IFnIKd+Zi1zaCPGfas9ekqCSj3vZQ"
+            b"j7lCJVGUGuuqnSDvsed6g2Pz/g6mJUa+TzjxN+8wU5oj5YVUK+aing1"
+            b"zPSA2MDCfx3+YzjxVwNoGixOz6Yx9ijT4pUsAYQAf1o9R+6W1/IpGgu"
+            b"oax714QILT9heqIowwlHzlUZc1UAYs0/JA4CbDZaw9hlJyzMqe/aE46"
+            b"efqPDOpO3vCpOSRcSyzh02WijPvEEaPejQRWg8RX93othZ615MT7dqp"
+            b"ECAwEAAaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGA"
+            b"QUFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0G"
+            b"A1UdDgQWBBTgod3R6vejt6kOASAApA19xIG6kTANBgkqhkiG9w0BAQ0"
+            b"FAAOCAQEAVfz0okK2bh3OQE8cWNbJ5PjJRSAJEqVUvYaTlS0Nqkyuaj"
+            b"gicP3hb/pF8FvaVaB6r7LqgBxyW5NNL1xwdNLt60M2zaULL6Fhm1vzM"
+            b"sSMc2ynkyN4++ODwii674YcQAnkUh+ZGIx+CTdZBWJfVM9dZb7QjgBT"
+            b"nVukeFwN2EOOBSpiQSBpcoeJEEAq9csDVRhEfcB8Wtz7TTItgOVsilY"
+            b"dQY56ON5XszjCki6UA3GwdQbBEHjWF2WERqXWrojrSSNOYDvxM5mrEx"
+            b"sG1npzUTsaIr9w8ty1beh/2aToCMREvpiPFOXnVV/ovHMU1lFQTNeQ0"
+            b"OI7elR0nJ0peai30eMpQQ=="
+        )
 
-        expected_hash = '556E1C1784E3B957370B7F544F62C533CB2CA5C1DAE0706FAEF' \
-                        '00544E1AD2B76FF25CFBE69B1C4E630C3BB0207DF11314C6738' \
-                        'BCAED7E071D7BFBF2C9DFAB85D'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "556E1C1784E3B957370B7F544F62C533CB2CA5C1DAE0706FAEF"
+            "00544E1AD2B76FF25CFBE69B1C4E630C3BB0207DF11314C6738"
+            "BCAED7E071D7BFBF2C9DFAB85D"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha1(self):
-        cert_der = b'MIIBjjCCATSgAwIBAgIQRCJw7nbtvJ5F8wikRmwgizAJBgcqhkjOPQQ' \
-                   b'BMBUxEzARBgNVBAMMClNFUlZFUjIwMTYwHhcNMTcwNTMwMDgwMzE3Wh' \
-                   b'cNMTgwNTMwMDgyMzE3WjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MFkwE' \
-                   b'wYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEk3fOh178kRglmnPKe9K/mbgi' \
-                   b'gf8YgNq62rF2EpfzpyQY0eGw4xnmKDG73aZ+ATSlV2IybxiUVsKyMUn' \
-                   b'LhPfvmaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQ' \
-                   b'UFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0GA' \
-                   b'1UdDgQWBBQSK8qwmiQmyAWWya3FxQDj9wqQAzAJBgcqhkjOPQQBA0kA' \
-                   b'MEYCIQCiOsP56Iqo+cHRvCp2toj65Mgxo/PQY1tn+S3WH4RJFQIhAJe' \
-                   b'gGQuaPWg6aCWV+2+6pNCNMdg/Nix+mMOJ88qCBNHi'
+        cert_der = (
+            b"MIIBjjCCATSgAwIBAgIQRCJw7nbtvJ5F8wikRmwgizAJBgcqhkjOPQQ"
+            b"BMBUxEzARBgNVBAMMClNFUlZFUjIwMTYwHhcNMTcwNTMwMDgwMzE3Wh"
+            b"cNMTgwNTMwMDgyMzE3WjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MFkwE"
+            b"wYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEk3fOh178kRglmnPKe9K/mbgi"
+            b"gf8YgNq62rF2EpfzpyQY0eGw4xnmKDG73aZ+ATSlV2IybxiUVsKyMUn"
+            b"LhPfvmaNnMGUwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQ"
+            b"UFBwMCBggrBgEFBQcDATAVBgNVHREEDjAMggpTRVJWRVIyMDE2MB0GA"
+            b"1UdDgQWBBQSK8qwmiQmyAWWya3FxQDj9wqQAzAJBgcqhkjOPQQBA0kA"
+            b"MEYCIQCiOsP56Iqo+cHRvCp2toj65Mgxo/PQY1tn+S3WH4RJFQIhAJe"
+            b"gGQuaPWg6aCWV+2+6pNCNMdg/Nix+mMOJ88qCBNHi"
+        )
 
-        expected_hash = '1EC9AD46DEE9340E4503CFFDB5CD810CB26B778F46BE95D5EAF' \
-                        '999DCB1C45EDA'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "1EC9AD46DEE9340E4503CFFDB5CD810CB26B778F46BE95D5EAF" "999DCB1C45EDA"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha256(self):
-        cert_der = b'MIIBjzCCATWgAwIBAgIQeNQTxkMgq4BF9tKogIGXUTAKBggqhkjOPQQ' \
-                   b'DAjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxN1' \
-                   b'oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABDAfXTLOaC3ElgErlgk2tBlM' \
-                   b'wf9XmGlGBw4vBtMJap1hAqbsdxFm6rhK3QU8PFFpv8Z/AtRG7ba3UwQ' \
-                   b'prkssClejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUnFDE8824TYAiBeX4fghEEg33UgYwCgYIKoZIzj0EAwID' \
-                   b'SAAwRQIhAK3rXA4/0i6nm/U7bi6y618Ci2Is8++M3tYIXnEsA7zSAiA' \
-                   b'w2s6bJoI+D7Xaey0Hp0gkks9z55y976keIEI+n3qkzw=='
+        cert_der = (
+            b"MIIBjzCCATWgAwIBAgIQeNQTxkMgq4BF9tKogIGXUTAKBggqhkjOPQQ"
+            b"DAjAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxN1"
+            b"oXDTE4MDUzMDA4MjMxN1owFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABDAfXTLOaC3ElgErlgk2tBlM"
+            b"wf9XmGlGBw4vBtMJap1hAqbsdxFm6rhK3QU8PFFpv8Z/AtRG7ba3UwQ"
+            b"prkssClejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUnFDE8824TYAiBeX4fghEEg33UgYwCgYIKoZIzj0EAwID"
+            b"SAAwRQIhAK3rXA4/0i6nm/U7bi6y618Ci2Is8++M3tYIXnEsA7zSAiA"
+            b"w2s6bJoI+D7Xaey0Hp0gkks9z55y976keIEI+n3qkzw=="
+        )
 
-        expected_hash = 'FECF1B2585449990D9E3B2C92D3F597EC8354E124EDA751D948' \
-                        '37C2C89A2C155'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "FECF1B2585449990D9E3B2C92D3F597EC8354E124EDA751D948" "37C2C89A2C155"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha384(self):
-        cert_der = b'MIIBjzCCATWgAwIBAgIQcO3/jALdQ6BOAoaoseLSCjAKBggqhkjOPQQ' \
-                   b'DAzAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxOF' \
-                   b'oXDTE4MDUzMDA4MjMxOFowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABJLjZH274heB/8PhmhWWCIVQ' \
-                   b'Wle1hBZEN3Tk2yWSKaz9pz1bjwb9t79lVpQE9tvGL0zP9AqJYHcVOO9' \
-                   b'YG9trqfejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUkRajoFr8qZ/8L8rKB3zGiGolDygwCgYIKoZIzj0EAwMD' \
-                   b'SAAwRQIgfi8dAxXljCMSvngtDtagGCTGBs7Xxh8Z3WX6ZwJZsHYCIQC' \
-                   b'D4iNReh1afXKYC0ipjXWAIkiihnEEycCIQMbkMNst7A=='
+        cert_der = (
+            b"MIIBjzCCATWgAwIBAgIQcO3/jALdQ6BOAoaoseLSCjAKBggqhkjOPQQ"
+            b"DAzAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA4MDMxOF"
+            b"oXDTE4MDUzMDA4MjMxOFowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABJLjZH274heB/8PhmhWWCIVQ"
+            b"Wle1hBZEN3Tk2yWSKaz9pz1bjwb9t79lVpQE9tvGL0zP9AqJYHcVOO9"
+            b"YG9trqfejZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUkRajoFr8qZ/8L8rKB3zGiGolDygwCgYIKoZIzj0EAwMD"
+            b"SAAwRQIgfi8dAxXljCMSvngtDtagGCTGBs7Xxh8Z3WX6ZwJZsHYCIQC"
+            b"D4iNReh1afXKYC0ipjXWAIkiihnEEycCIQMbkMNst7A=="
+        )
 
-        expected_hash = 'D2987AD8F20E8316A831261B74EF7B3E55155D0922E07FFE546' \
-                        '20806982B68A73A5E3C478BAA5E7714135CB26D980749'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "D2987AD8F20E8316A831261B74EF7B3E55155D0922E07FFE546"
+            "20806982B68A73A5E3C478BAA5E7714135CB26D980749"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_ecdsa_sha512(self):
-        cert_der = b'MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ' \
-                   b'DBDAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV' \
-                   b'oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA' \
-                   b'AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp' \
-                   b'lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwQD' \
-                   b'RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ' \
-                   b'D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li'
+        cert_der = (
+            b"MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ"
+            b"DBDAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV"
+            b"oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA"
+            b"AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp"
+            b"lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwQD"
+            b"RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ"
+            b"D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li"
+        )
 
-        expected_hash = 'E5CB68B2F843D63BF40BCB2007608F8197618392783F2330E5E' \
-                        'F19A5BD8F0B2FAAC861855FBB63A221CC46FC1E226A072411AF' \
-                        '175DDE479281E006878B348059'
-        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+        expected_hash = (
+            "E5CB68B2F843D63BF40BCB2007608F8197618392783F2330E5E"
+            "F19A5BD8F0B2FAAC861855FBB63A221CC46FC1E226A072411AF"
+            "175DDE479281E006878B348059"
+        )
+        actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+            base64.b64decode(cert_der)
+        )
         assert actual_hash == base64.b16decode(expected_hash)
 
     def test_invalid_signature_algorithm(self):
         # Manually edited from test_ecdsa_sha512 to change the OID to '1.2.840.10045.4.3.5'
-        cert_der = b'MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ' \
-                   b'DBTAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV' \
-                   b'oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM' \
-                   b'BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA' \
-                   b'AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp' \
-                   b'lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg' \
-                   b'EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB' \
-                   b'gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwUD' \
-                   b'RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ' \
-                   b'D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li'
+        cert_der = (
+            b"MIIBjjCCATWgAwIBAgIQHVj2AGEwd6pOOSbcf0skQDAKBggqhkjOPQQ"
+            b"DBTAVMRMwEQYDVQQDDApTRVJWRVIyMDE2MB4XDTE3MDUzMDA3NTUzOV"
+            b"oXDTE4MDUzMDA4MTUzOVowFTETMBEGA1UEAwwKU0VSVkVSMjAxNjBZM"
+            b"BMGByqGSM49AgEGCCqGSM49AwEHA0IABL8d9S++MFpfzeH8B3vG/PjA"
+            b"AWg8tGJVgsMw9nR+OfC9ltbTUwhB+yPk3JPcfW/bqsyeUgq4//LhaSp"
+            b"lOWFNaNqjZzBlMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBg"
+            b"EFBQcDAgYIKwYBBQUHAwEwFQYDVR0RBA4wDIIKU0VSVkVSMjAxNjAdB"
+            b"gNVHQ4EFgQUKUkCgLlxoeai0EtQrZth1/BSc5kwCgYIKoZIzj0EAwUD"
+            b"RwAwRAIgRrV7CLpDG7KueyFA3ZDced9dPOcv2Eydx/hgrfxYEcYCIBQ"
+            b"D35JvzmqU05kSFV5eTvkhkaDObd7V55vokhm31+Li"
+        )
 
         expected_hash = None
-        expected_warning = "Failed to get signature algorithm from " \
-                           "certificate, unable to pass channel bindings:"
+        expected_warning = (
+            "Failed to get signature algorithm from "
+            "certificate, unable to pass channel bindings:"
+        )
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(base64.b64decode(cert_der))
+            actual_hash = requests_ntlm.requests_ntlm._get_certificate_hash(
+                base64.b64decode(cert_der)
+            )
             assert actual_hash == expected_hash
             assert expected_warning in str(w[-1].message)


### PR DESCRIPTION
Adds type annotation to the library including mypy sanity checks. Also
adds black and isort as the builtin sanity tests.

The MANIFEST.in has been updated to also include other files that should
be present in the sdist for people repackaging the library.

Fixes: https://github.com/requests/requests-ntlm/issues/117
Fixes: https://github.com/requests/requests-ntlm/issues/132