### PR TITLE
Update CI and version and ignore black diff

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Bulk black reformatting
+986a8ad007d7621a464ddee681769fc186a4ed01

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,18 @@ jobs:
         - python-version: '3.9'
         - python-version: '3.10'
         - python-version: '3.11'
+        - python-version: '3.12'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Run tests
       shell: bash
       run: |
-        python -m pip install -U pip setuptools
         python -m pip install .
         python -m pip install -r requirements.txt
 
@@ -65,24 +65,21 @@ jobs:
     - test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Installing baseline packages
-      run: |
-        echo "Installing baseline pip packages"
-        python -m pip install --upgrade pip setuptools wheel
+    - uses: actions/checkout@v4
 
     - name: Build package
-      run: python setup.py sdist bdist_wheel
+      run: |
+        python -m pip install build
+        python -m build
 
     - name: Capture Wheel and SDist
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: artifact
         path: dist/*
 
     - name: Publish
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.event.release.tag_name, 'v')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ mypy == 1.10.0
 pytest
 pytest-cov
 types-requests
-wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = requests_ntlm
-version = 1.2.0
+version = 1.3.0
 url = https://github.com/requests/requests-ntlm
 author = Ben Toews
 author_email = mastahyeti@gmail.com
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: ISC License (ISCL)
 
 [options]


### PR DESCRIPTION
Updates CI to use new action versions that are not deprecated. Bumps the version of the package to reflect the latest changes and add .git-blame-ignore-revs so the GitHub UI blame will ignore the black formatting changes.